### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Testing
 -------
 
 The `test` directory of the root source code repository contains the unittest
-files used to excersise the implementation. The *primary* tests are written in
+files used to exercise the implementation. The *primary* tests are written in
 Python and correspond to the essential, practical, functional, and durable
 modules. The Java tests, which are also written in Python, wrap the Java classes
 with a compatible interface and use the Python unit tests to exercise the Java

--- a/paxos/durable.py
+++ b/paxos/durable.py
@@ -20,7 +20,7 @@ corrupted-on-disk, the implementation will assume the initial write failed and
 will return the previously saved state (assuming it isn't similarly
 corrupted). Consequently, there is a small but real chance that an application
 may save its state with this implementation, make promises to external
-entities, crash, and reneg on those promises after recovery. The likelyhood is,
+entities, crash, and reneg on those promises after recovery. The likelihood is,
 of course, very very low so this implementation should be suitable for most
 "good" reliability systems. Just don't implement a life-support system based on
 this code...

--- a/paxos/external.py
+++ b/paxos/external.py
@@ -34,7 +34,7 @@ class ExternalNode (practical.Node):
     of eternal leadership battles is also the responsibility of the caller.
 
     When leadership is acquired, the node will broadcast a leadership proclamation,
-    delcaring itself the leader of the instance. This relieves peer nodes of the
+    declaring itself the leader of the instance. This relieves peer nodes of the
     responsibility of tracking promises for all prepare messages.
     '''
 

--- a/paxos/practical.py
+++ b/paxos/practical.py
@@ -21,10 +21,10 @@ class Messenger (essential.Messenger):
 
     def on_leadership_acquired(self):
         '''
-        Called when leadership has been aquired. This is not a guaranteed
+        Called when leadership has been acquired. This is not a guaranteed
         position. Another node may assume leadership at any time and it's
         even possible that another may have successfully done so before this
-        callback is exectued. Use this method with care.
+        callback is executed. Use this method with care.
 
         The safe way to guarantee leadership is to use a full Paxos instance
         with the resolution value being the UID of the leader node. To avoid


### PR DESCRIPTION
There are small typos in:
- README.md
- paxos/durable.py
- paxos/external.py
- paxos/practical.py

Fixes:
- Should read `likelihood` rather than `likelyhood`.
- Should read `exercise` rather than `excersise`.
- Should read `executed` rather than `exectued`.
- Should read `declaring` rather than `delcaring`.
- Should read `acquired` rather than `aquired`.

Closes #7